### PR TITLE
DERBY-6928 and DERBY-5849 changes

### DIFF
--- a/java/build/org/apache/derbyBuild/ODBCMetadataGenerator.java
+++ b/java/build/org/apache/derbyBuild/ODBCMetadataGenerator.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.ArrayList;
 
 import org.apache.derby.shared.common.sanity.SanityManager;
+import org.apache.derby.iapi.types.TypeId;
 
 /**
  * This class is used at COMPILE TIME ONLY.  It is responsible for generating
@@ -937,6 +938,10 @@ public class ODBCMetadataGenerator {
 	 *  if the received column in the received query has
 	 * 	no known target type.
 	 */
+	
+	// DERBY - 6928
+	// Use org.apache.derby.iapi.types.TypeId.SMALLINT_NAME instead of hardcoding "SMALLINT" 
+	
 	private String getCastInfoForCol(String queryName,
 		String colName)
 	{
@@ -950,7 +955,8 @@ public class ODBCMetadataGenerator {
 				colName.equals("SQL_DATA_TYPE") ||
 				colName.equals("SQL_DATETIME_SUB"))
 			{
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 		else if (queryName.equals("getColumns")) {
@@ -961,29 +967,34 @@ public class ODBCMetadataGenerator {
 				colName.equals("SQL_DATA_TYPE") ||
 				colName.equals("SQL_DATETIME_SUB"))
 			{
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 		else if (queryName.equals("getProcedureColumns")) {
 			if (colName.equals("DATA_TYPE")) {
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 		else if (queryName.equals("getVersionColumns")) {
 			if (colName.equals("DATA_TYPE")) {
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 		else if (queryName.startsWith("getBestRowIdentifier")) {
 			if (colName.equals("DATA_TYPE")) {
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 		else if (queryName.equals("getIndexInfo")) {
 			if (colName.equals("NON_UNIQUE") ||
 				colName.equals("TYPE"))
 			{
-				return "SMALLINT";
+				//return "SMALLINT";
+				return TypeId.SMALLINT_NAME;
 			}
 		}
 

--- a/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
+++ b/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
@@ -99,7 +99,8 @@ public final class PageKey
 	}
 
 	public String toString() {
-		return "Page(" + pageNumber + "," + container.toString() + ")";
+		//return "Page(" + pageNumber + "," + container.toString() + ")";
+		return "Could not read page " + pageNumber + " from segment " + container.getSegmentId() + "of container " + container.getContainerId();
 	}
 
 }

--- a/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
+++ b/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
@@ -100,7 +100,8 @@ public final class PageKey
 
 	public String toString() {
 		//return "Page(" + pageNumber + "," + container.toString() + ")";
-		return "Could not read page " + pageNumber + " from segment " + container.getSegmentId() + "of container " + container.getContainerId();
+		return "Could not read page " + pageNumber + " from segment " 
+			+ container.getSegmentId() + "of container " + container.getContainerId();
 	}
 
 }

--- a/java/tools/org/apache/derby/tools/JDBCDisplayUtil.java
+++ b/java/tools/org/apache/derby/tools/JDBCDisplayUtil.java
@@ -958,6 +958,8 @@ public class JDBCDisplayUtil {
 					ShowWarnings(out, rs);
 					numberOfRowsSelected++;
 				}
+				// print number of rows in the result set
+				 indentedPrintLine( out, indentLevel, numberOfRowsSelected + " rows in the result set");
 			} catch (SQLException e) {
 				// REVISIT: might want to check the exception
 				// and for some, not bother with the retry.


### PR DESCRIPTION
org.apache.derby.iapi.types.TypeId.SMALLINT_NAME is used instead of hard coding "SMALLINT" in the above method.