### PR TITLE
Make the project OSGi compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
+/bnd/*.jar
+/bnd/*.mf
 /classes*/
 /jars/
 /generated/

--- a/bnd/derby.bnd
+++ b/bnd/derby.bnd
@@ -1,0 +1,101 @@
+-classpath:       ../jars/sane/derby.jar
+-include:         ../classes/version.properties
+-includeresource: @derby.jar!/META-INF/**, @derby.jar!/module-info.class
+
+-output:       derby.jar
+-savemanifest: derby.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Embedded Engine ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.engine
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Bundle-Activator:    org.apache.derby.osgi.EmbeddedActivator
+
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Private-Package: *
+Sealed:          true
+
+Import-Package:\
+javax.naming;resolution="optional", \
+*
+
+Export-Package: \
+org.apache.derby.agg, \
+org.apache.derby.authentication, \
+org.apache.derby.catalog, \
+org.apache.derby.vti, \
+org.apache.derby.security, \
+org.apache.derby.diag, \
+org.apache.derby.iapi.db, \
+org.apache.derby.iapi.services.io, \
+org.apache.derby.iapi.services.loader, \
+org.apache.derby.iapi.sql, \
+org.apache.derby.iapi.sql.conn, \
+org.apache.derby.iapi.sql.execute, \
+org.apache.derby.iapi.store.access, \
+org.apache.derby.iapi.types, \
+org.apache.derby.iapi.util, \
+org.apache.derby.impl.sql.execute, \
+org.apache.derby.impl.load, \
+org.apache.derby.impl.jdbc, \
+org.apache.derby.catalog.types, \
+org.apache.derby.database, \
+org.apache.derby.iapi.jdbc, \
+org.apache.derby.iapi.services.cache, \
+org.apache.derby.iapi.services.context, \
+org.apache.derby.iapi.services.crypto, \
+org.apache.derby.iapi.services.daemon, \
+org.apache.derby.iapi.services.diag, \
+org.apache.derby.iapi.services.jmx, \
+org.apache.derby.iapi.services.locks, \
+org.apache.derby.iapi.services.monitor, \
+org.apache.derby.iapi.services.property, \
+org.apache.derby.iapi.services.uuid, \
+org.apache.derby.iapi.sql.compile, \
+org.apache.derby.iapi.sql.depend, \
+org.apache.derby.iapi.sql.dictionary, \
+org.apache.derby.iapi.store.access.conglomerate, \
+org.apache.derby.iapi.store.access.xa, \
+org.apache.derby.iapi.store.raw, \
+org.apache.derby.iapi.store.raw.data, \
+org.apache.derby.iapi.store.raw.log, \
+org.apache.derby.iapi.store.raw.xact, \
+org.apache.derby.iapi.transaction, \
+org.apache.derby.impl.io, \
+org.apache.derby.impl.io.vfmem, \
+org.apache.derby.impl.jdbc.authentication, \
+org.apache.derby.impl.services.jce, \
+org.apache.derby.impl.sql, \
+org.apache.derby.impl.sql.catalog, \
+org.apache.derby.impl.store.access.btree, \
+org.apache.derby.impl.store.access.btree.index, \
+org.apache.derby.impl.store.access.conglomerate, \
+org.apache.derby.impl.store.access.heap, \
+org.apache.derby.impl.store.raw.data, \
+org.apache.derby.impl.store.raw.log, \
+org.apache.derby.io, \
+org.apache.derby.mbeans, \
+

--- a/bnd/derby.bnd
+++ b/bnd/derby.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derby.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derby.jar!/META-INF/**, @derby.jar!/module-info.class
 
--output:       derby.jar
--savemanifest: derby.mf
+-output:       ../classes/bnd/derby.jar
+-savemanifest: ../classes/bnd/derby.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -39,7 +39,10 @@ Private-Package: *
 Sealed:          true
 
 Import-Package:\
-javax.naming;resolution="optional", \
+javax.naming;resolution:="optional", \
+javax.naming.directory;resolution:="optional", \
+javax.management;resolution:="optional", \
+javax.transaction.xa;resolution:="optional", \
 *
 
 Export-Package: \

--- a/bnd/derby.bnd
+++ b/bnd/derby.bnd
@@ -1,9 +1,11 @@
 -classpath:       ../jars/sane/derby.jar
--include:         ../classes/bnd/version.properties
+-include:         ../classes/bnd/version.properties, locales.properties
 -includeresource: @derby.jar!/META-INF/**, @derby.jar!/module-info.class
 
 -output:       ../classes/bnd/derby.jar
 -savemanifest: ../classes/bnd/derby.mf
+
+Class-Path: derbyshared.jar ${localeList}
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"

--- a/bnd/derbyLocale.bnd
+++ b/bnd/derbyLocale.bnd
@@ -1,0 +1,38 @@
+-include:\
+../classes/locale.properties, \
+../classes/version.properties
+
+-classpath:       ../jars/sane/derbyLocale_${locale.iname}.jar
+-includeresource: @derbyLocale_${locale.iname}.jar!/META-INF/**, @derbyLocale_${locale.iname}.jar!/module-info.class
+
+-output:       derbyLocale_${locale.iname}.jar
+-savemanifest: derbyLocale_${locale.iname}.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Locale (${locale.ename}) ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.locale_${locale.iname}
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Export-Package:\
+org.apache.derby.info.locale_${locale.iname}, \
+org.apache.derby.loc.locale_${locale.iname}, \
+org.apache.derby.loc.tools.locale_${locale.iname}, \
+

--- a/bnd/derbyLocale.bnd
+++ b/bnd/derbyLocale.bnd
@@ -1,12 +1,12 @@
 -include:\
-../classes/locale.properties, \
-../classes/version.properties
+../classes/bnd/locale.properties, \
+../classes/bnd/version.properties
 
 -classpath:       ../jars/sane/derbyLocale_${locale.iname}.jar
 -includeresource: @derbyLocale_${locale.iname}.jar!/META-INF/**, @derbyLocale_${locale.iname}.jar!/module-info.class
 
--output:       derbyLocale_${locale.iname}.jar
--savemanifest: derbyLocale_${locale.iname}.mf
+-output:       ../classes/bnd/derbyLocale_${locale.iname}.jar
+-savemanifest: ../classes/bnd/derbyLocale_${locale.iname}.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -30,6 +30,8 @@ Bundle-Name:         Apache Derby Locale (${locale.ename}) ${major}.${minor}
 Bundle-SymbolicName: org.apache.derby.locale_${locale.iname}
 Bundle-Vendor:       Apache Software Foundation
 Bundle-Version:      ${major}.${minor}.${maint}
+
+Fragment-Host: org.apache.derby.commons;bundle-version=${major}.${minor}
 
 Export-Package:\
 org.apache.derby.info.locale_${locale.iname}, \

--- a/bnd/derbyclient.bnd
+++ b/bnd/derbyclient.bnd
@@ -1,0 +1,48 @@
+-classpath:       ../jars/sane/derbyclient.jar
+-include:         ../classes/version.properties
+-includeresource: @derbyclient.jar!/META-INF/**, @derbyclient.jar!/module-info.class
+
+-output:       derbyclient.jar
+-savemanifest: derbyclient.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Network Client ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.client
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Private-Package:     *
+Sealed:              true
+
+Import-Package:\
+javax.naming;resolution="optional", \
+*
+
+Export-Package:\
+org.apache.derby.client, \
+org.apache.derby.client.am, \
+org.apache.derby.client.am.stmtcache, \
+org.apache.derby.client.net, \
+org.apache.derby.loc.client, \
+

--- a/bnd/derbyclient.bnd
+++ b/bnd/derbyclient.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derbyclient.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derbyclient.jar!/META-INF/**, @derbyclient.jar!/module-info.class
 
--output:       derbyclient.jar
--savemanifest: derbyclient.mf
+-output:       ../classes/bnd/derbyclient.jar
+-savemanifest: ../classes/bnd/derbyclient.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -36,7 +36,7 @@ Private-Package:     *
 Sealed:              true
 
 Import-Package:\
-javax.naming;resolution="optional", \
+javax.naming;resolution:="optional", \
 *
 
 Export-Package:\

--- a/bnd/derbyclient.bnd
+++ b/bnd/derbyclient.bnd
@@ -1,9 +1,11 @@
 -classpath:       ../jars/sane/derbyclient.jar
--include:         ../classes/bnd/version.properties
+-include:         ../classes/bnd/version.properties, locales.properties
 -includeresource: @derbyclient.jar!/META-INF/**, @derbyclient.jar!/module-info.class
 
 -output:       ../classes/bnd/derbyclient.jar
 -savemanifest: ../classes/bnd/derbyclient.mf
+
+Class-Path: derbyshared.jar ${localeList}
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"

--- a/bnd/derbynet.bnd
+++ b/bnd/derbynet.bnd
@@ -1,0 +1,50 @@
+-classpath:       ../jars/sane/derbynet.jar
+-include:         ../classes/version.properties
+-includeresource: @derbynet.jar!/META-INF/**, @derbynet.jar!/module-info.class
+
+-output:       derbynet.jar
+-savemanifest: derbynet.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Network Server ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.server
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Main-Class:          org.apache.derby.drda.NetworkServerControl
+Private-Package:     *
+Sealed:              true
+
+Import-Package:\
+javax.servlet;resolution="optional", \
+javax.servlet.http;resolution="optional", \
+javax.transaction.xa;resolution="optional", \
+*
+
+Export-Package:\
+org.apache.derby.drda, \
+org.apache.derby.impl.drda, \
+org.apache.derby.loc.drda, \
+org.apache.derby.mbeans.drda, \
+

--- a/bnd/derbynet.bnd
+++ b/bnd/derbynet.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derbynet.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derbynet.jar!/META-INF/**, @derbynet.jar!/module-info.class
 
--output:       derbynet.jar
--savemanifest: derbynet.mf
+-output:       ../classes/bnd/derbynet.jar
+-savemanifest: ../classes/bnd/derbynet.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -37,9 +37,9 @@ Private-Package:     *
 Sealed:              true
 
 Import-Package:\
-javax.servlet;resolution="optional", \
-javax.servlet.http;resolution="optional", \
-javax.transaction.xa;resolution="optional", \
+javax.servlet;resolution:="optional", \
+javax.servlet.http;resolution:="optional", \
+javax.transaction.xa;resolution:="optional", \
 *
 
 Export-Package:\

--- a/bnd/derbynet.bnd
+++ b/bnd/derbynet.bnd
@@ -5,6 +5,8 @@
 -output:       ../classes/bnd/derbynet.jar
 -savemanifest: ../classes/bnd/derbynet.mf
 
+Class-Path: derby.jar derbyshared.jar
+
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
 # so that bnd doesn't try to infer the requirement from the bytecode (because

--- a/bnd/derbyoptionaltools.bnd
+++ b/bnd/derbyoptionaltools.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derbyoptionaltools.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derbyoptionaltools.jar!/META-INF/**, @derbyoptionaltools.jar!/module-info.class
 
--output:       derbyoptionaltools.jar
--savemanifest: derbyoptionaltools.mf
+-output:       ../classes/bnd/derbyoptionaltools.jar
+-savemanifest: ../classes/bnd/derbyoptionaltools.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"

--- a/bnd/derbyoptionaltools.bnd
+++ b/bnd/derbyoptionaltools.bnd
@@ -1,9 +1,11 @@
 -classpath:       ../jars/sane/derbyoptionaltools.jar
--include:         ../classes/bnd/version.properties
+-include:         ../classes/bnd/version.properties, locales.properties
 -includeresource: @derbyoptionaltools.jar!/META-INF/**, @derbyoptionaltools.jar!/module-info.class
 
 -output:       ../classes/bnd/derbyoptionaltools.jar
 -savemanifest: ../classes/bnd/derbyoptionaltools.mf
+
+Class-Path: derbyshared.jar ${localeList}
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"

--- a/bnd/derbyoptionaltools.bnd
+++ b/bnd/derbyoptionaltools.bnd
@@ -1,0 +1,43 @@
+-classpath:       ../jars/sane/derbyoptionaltools.jar
+-include:         ../classes/version.properties
+-includeresource: @derbyoptionaltools.jar!/META-INF/**, @derbyoptionaltools.jar!/module-info.class
+
+-output:       derbyoptionaltools.jar
+-savemanifest: derbyoptionaltools.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Optional Tools ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.optionaltools
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Private-Package:     *
+Sealed:              true
+
+Export-Package:\
+org.apache.derby.optional.api, \
+org.apache.derby.optional.lucene, \
+org.apache.derby.optional.dump, \
+org.apache.derby.optional.json, \
+

--- a/bnd/derbyshared.bnd
+++ b/bnd/derbyshared.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derbyshared.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derbyshared.jar!/META-INF/**, @derbyshared.jar!/module-info.class
 
--output:       derbyshared.jar
--savemanifest: derbyshared.mf
+-output:       ../classes/bnd/derbyshared.jar
+-savemanifest: ../classes/bnd/derbyshared.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -36,7 +36,7 @@ Private-Package:     *
 Sealed:              true
 
 Import-Package:\
-com.ibm.jvm;resolution="optional", \
+com.ibm.jvm;resolution:="optional", \
 *
 
 

--- a/bnd/derbyshared.bnd
+++ b/bnd/derbyshared.bnd
@@ -1,9 +1,11 @@
 -classpath:       ../jars/sane/derbyshared.jar
--include:         ../classes/bnd/version.properties
+-include:         ../classes/bnd/version.properties, locales.properties
 -includeresource: @derbyshared.jar!/META-INF/**, @derbyshared.jar!/module-info.class
 
 -output:       ../classes/bnd/derbyshared.jar
 -savemanifest: ../classes/bnd/derbyshared.mf
+
+Class-Path: ${localeList}
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"

--- a/bnd/derbyshared.bnd
+++ b/bnd/derbyshared.bnd
@@ -1,0 +1,54 @@
+-classpath:       ../jars/sane/derbyshared.jar
+-include:         ../classes/version.properties
+-includeresource: @derbyshared.jar!/META-INF/**, @derbyshared.jar!/module-info.class
+
+-output:       derbyshared.jar
+-savemanifest: derbyshared.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Commons ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.commons
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Private-Package:     *
+Sealed:              true
+
+Import-Package:\
+com.ibm.jvm;resolution="optional", \
+*
+
+
+Export-Package:\
+org.apache.derby.shared.api, \
+org.apache.derby.shared.common.drda, \
+org.apache.derby.shared.common.error, \
+org.apache.derby.shared.common.i18n, \
+org.apache.derby.shared.common.info, \
+org.apache.derby.shared.common.reference, \
+org.apache.derby.shared.common.sanity, \
+org.apache.derby.shared.common.security, \
+org.apache.derby.shared.common.stream, \
+org.apache.derby.shared.common.util, \
+

--- a/bnd/derbytools.bnd
+++ b/bnd/derbytools.bnd
@@ -5,6 +5,8 @@
 -output:       ../classes/bnd/derbytools.jar
 -savemanifest: ../classes/bnd/derbytools.mf
 
+Class-Path: derby.jar derbyclient.jar derbynet.jar
+
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
 # so that bnd doesn't try to infer the requirement from the bytecode (because

--- a/bnd/derbytools.bnd
+++ b/bnd/derbytools.bnd
@@ -1,0 +1,49 @@
+-classpath:       ../jars/sane/derbytools.jar
+-include:         ../classes/version.properties
+-includeresource: @derbytools.jar!/META-INF/**, @derbytools.jar!/module-info.class
+
+-output:       derbytools.jar
+-savemanifest: derbytools.mf
+
+#
+# Specify that the minimum Java requirement is Java 8. We specify "-noee"
+# so that bnd doesn't try to infer the requirement from the bytecode (because
+# module descriptors will cause it to believe that Java 9 is a hard
+# requirement).
+#
+-noee: true
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+#
+# Remove headers that reduce reproducibility.
+#
+-noextraheaders: true
+
+#
+# Specify basic OSGi metadata.
+#
+# Specify that all packages are private by default, and sealed. We will
+# override the privacy of an explicit list of packages by exporting them
+# with Export-Package.
+#
+Bundle-DocURL:       https://db.apache.org/derby/manuals/index.html
+Bundle-Name:         Apache Derby Tools ${major}.${minor}
+Bundle-SymbolicName: org.apache.derby.tools
+Bundle-Vendor:       Apache Software Foundation
+Bundle-Version:      ${major}.${minor}.${maint}
+
+Private-Package:     *
+Sealed:              true
+
+Export-Package:\
+org.apache.derby.iapi.tools.i18n, \
+org.apache.derby.impl.tools.ij, \
+org.apache.derby.impl.tools.optional, \
+org.apache.derby.impl.tools.optional, \
+org.apache.derby.impl.tools.planexporter, \
+org.apache.derby.impl.tools.sysinfo, \
+org.apache.derby.info.tools, \
+org.apache.derby.jdbc, \
+org.apache.derby.loc.tools, \
+org.apache.derby.tools, \
+

--- a/bnd/derbytools.bnd
+++ b/bnd/derbytools.bnd
@@ -1,9 +1,9 @@
 -classpath:       ../jars/sane/derbytools.jar
--include:         ../classes/version.properties
+-include:         ../classes/bnd/version.properties
 -includeresource: @derbytools.jar!/META-INF/**, @derbytools.jar!/module-info.class
 
--output:       derbytools.jar
--savemanifest: derbytools.mf
+-output:       ../classes/bnd/derbytools.jar
+-savemanifest: ../classes/bnd/derbytools.mf
 
 #
 # Specify that the minimum Java requirement is Java 8. We specify "-noee"
@@ -34,6 +34,17 @@ Bundle-Version:      ${major}.${minor}.${maint}
 
 Private-Package:     *
 Sealed:              true
+
+Import-Package:\
+com.ibm.db2.jcc;resolution:="optional",\
+javax.naming.directory;resolution:="optional",\
+javax.naming.spi;resolution:="optional",\
+javax.naming;resolution:="optional",\
+javax.sql,\
+javax.transaction.xa;resolution:="optional",\
+javax.xml.transform,\
+javax.xml.transform.stream,\
+*
 
 Export-Package:\
 org.apache.derby.iapi.tools.i18n, \

--- a/bnd/locales.properties
+++ b/bnd/locales.properties
@@ -1,0 +1,15 @@
+localeList=\
+  derbyLocale_cs.jar \
+  derbyLocale_de_DE.jar \
+  derbyLocale_es.jar \
+  derbyLocale_fr.jar \
+  derbyLocale_hu.jar \
+  derbyLocale_it.jar \
+  derbyLocale_ja_JP.jar \
+  derbyLocale_ko_KR.jar \
+  derbyLocale_pl.jar \
+  derbyLocale_pt_BR.jar \
+  derbyLocale_ru.jar \
+  derbyLocale_zh_CN.jar \
+  derbyLocale_zh_TW.jar \
+

--- a/build.xml
+++ b/build.xml
@@ -1356,6 +1356,7 @@
   <target name="initjars" depends="setsanityname,getsvnversion,setCompilerProperties">
     <property name="derby.jar.dir" value="${jarsdist.dir}/${sanity.name}"/>
     <property name="derby.jar.topdir" value="${jarsdist.dir}"/>
+    <mkdir dir="${out.bnd.dir}"/>
     <mkdir dir="${derby.jar.dir}"/>
     <mkdir dir="${derby.jar.dir}/lists"/>
 
@@ -1427,7 +1428,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derby.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derby.jar"/>
     </delete>
     <exec executable="java"
           failifexecutionfails="true">
@@ -1436,14 +1437,14 @@
       <arg value="bnd/derby.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derby.jar"
-         manifest="bnd/derby.mf"
+         manifest="${out.bnd.dir}/derby.mf"
          update="true"/>
   </target>
 
   <!-- Produce a properties file containing version information. -->
   <!-- Used when producing OSGi manifests. -->
   <target name="version.properties">
-    <propertyfile file="classes/version.properties">
+    <propertyfile file="${out.bnd.dir}/version.properties">
       <entry key="major" value="${major}"/>
       <entry key="minor" value="${minor}"/>
       <entry key="maint" value="${maint}"/>
@@ -1504,7 +1505,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derbytools.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derbytools.jar"/>
     </delete>
     <exec executable="java"
           failifexecutionfails="true">
@@ -1513,7 +1514,7 @@
       <arg value="bnd/derbytools.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derbytools.jar"
-         manifest="bnd/derbytools.mf"
+         manifest="${out.bnd.dir}/derbytools.mf"
          update="true"/>
   </target>
 
@@ -1551,7 +1552,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derbyoptionaltools.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derbyoptionaltools.jar"/>
     </delete>
     <exec executable="java"
           failifexecutionfails="true">
@@ -1560,7 +1561,7 @@
       <arg value="bnd/derbyoptionaltools.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derbyoptionaltools.jar"
-         manifest="bnd/derbyoptionaltools.mf"
+         manifest="${out.bnd.dir}/derbyoptionaltools.mf"
          update="true"/>
   </target>
 
@@ -1598,7 +1599,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derbynet.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derbynet.jar"/>
     </delete>
     <exec executable="java"
           failonerror="true"
@@ -1608,7 +1609,7 @@
       <arg value="bnd/derbynet.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derbynet.jar"
-         manifest="bnd/derbynet.mf"
+         manifest="${out.bnd.dir}/derbynet.mf"
          update="true"/>
   </target>
 
@@ -1656,7 +1657,7 @@
 
    <!-- Execute the bnd tool to generate a new jar manifest. -->
    <delete>
-     <fileset dir="bnd" includes="derbyclient.jar"/>
+     <fileset dir="${out.bnd.dir}" includes="derbyclient.jar"/>
    </delete>
    <exec executable="java"
          failonerror="true"
@@ -1666,7 +1667,7 @@
      <arg value="bnd/derbyclient.bnd"/>
    </exec>
    <jar destfile="${derby.jar.dir}/derbyclient.jar"
-        manifest="bnd/derbyclient.mf"
+        manifest="${out.bnd.dir}/derbyclient.mf"
         update="true"/>
   </target>
 
@@ -1695,7 +1696,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derbyshared.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derbyshared.jar"/>
     </delete>
     <exec executable="java"
           failonerror="true"
@@ -1705,7 +1706,7 @@
       <arg value="bnd/derbyshared.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derbyshared.jar"
-         manifest="bnd/derbyshared.mf"
+         manifest="${out.bnd.dir}/derbyshared.mf"
          update="true"/>
   </target>
 
@@ -1845,7 +1846,7 @@
 
     <!-- Execute the bnd tool to generate a new jar manifest. -->
     <delete>
-      <fileset dir="bnd" includes="derbyLocale_${locale.iname}.jar"/>
+      <fileset dir="${out.bnd.dir}" includes="derbyLocale_${locale.iname}.jar"/>
     </delete>
     <exec executable="java"
           failonerror="true"
@@ -1855,14 +1856,14 @@
       <arg value="bnd/derbyLocale.bnd"/>
     </exec>
     <jar destfile="${derby.jar.dir}/derbyLocale_${locale.iname}.jar"
-         manifest="bnd/derbyLocale_${locale.iname}.mf"
+         manifest="${out.bnd.dir}/derbyLocale_${locale.iname}.mf"
          update="true"/>
   </target>
 
   <!-- Produce a properties file containing locale information. -->
   <!-- Used when producing OSGi manifests. -->
   <target name="locale.properties">
-    <propertyfile file="classes/locale.properties">
+    <propertyfile file="${out.bnd.dir}/locale.properties">
       <entry key="locale.iname" value="${locale.iname}"/>
       <entry key="locale.ename" value="${locale.ename}"/>
     </propertyfile>

--- a/build.xml
+++ b/build.xml
@@ -1374,7 +1374,7 @@
 
 <!-- - - - - - - - - - - - - - - derby.jar target - - - - - - - - - - - -->
 
-  <target name="derbyjar" depends="initjars">
+  <target name="derbyjar" depends="initjars,versions.properties">
 
     <echo level="info" message="Beginning derby.jar ${sanity.name} build"/>
 
@@ -1415,30 +1415,39 @@
       <param name="driver.name" value="org.apache.derby.iapi.jdbc.AutoloadedDriver"/>
     </antcall>
 
-    <antcall target="make-core-derbyjar-manifest">
-      <param name="manifest.file" value="${derby.jar.dir}/lists/smf.mf"/>
-    </antcall>
-
-    <!-- add extra osgi bits to manifest -->
-
-    <manifest file="${derby.jar.dir}/lists/smf.mf"  mode="update">
-      <attribute name="Bundle-Activator" value="org.apache.derby.osgi.EmbeddedActivator"/>
-      <attribute name="Bundle-SymbolicName" value="derby"/>
-      <attribute name="DynamicImport-Package" value="*"/>
-      <attribute name="Export-Package" value="org.apache.derby.authentication,org.apache.derby.database,org.apache.derby.io,org.apache.derby.jdbc,org.apache.derby.vti"/> 
-    </manifest> 
-
     <jar destfile="${derby.jar.dir}/derby.jar"
          basedir="${out.engine.dir}"
          excludes="**/D_*,**/*.done,**/*Test.class,**/_Suite.class,**/modules.properties"
          compress="true"
-         filesonly="true"
-         manifest="${derby.jar.dir}/lists/smf.mf">
+         filesonly="true">
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/**,
                          org/apache/derby/modules.properties"/>
-   </jar>
+    </jar>
 
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derby.jar"/>
+    </delete>
+    <exec executable="java"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derby.bnd"/>
+    </exec>
+    <jar destfile="${derby.jar.dir}/derby.jar"
+         manifest="bnd/derby.mf"
+         update="true"/>
+  </target>
+
+  <!-- Produce a properties file containing version information. -->
+  <!-- Used when producing OSGi manifests. -->
+  <target name="versions.properties">
+    <propertyfile file="classes/version.properties">
+      <entry key="major" value="${major}"/>
+      <entry key="minor" value="${minor}"/>
+      <entry key="maint" value="${maint}"/>
+    </propertyfile>
   </target>
 
   <!-- Add localized jars to the classpath -->
@@ -1446,26 +1455,6 @@
       <manifest file="${manifest.file}" mode="${manifest.mode}">
           <attribute name="Class-Path" value="derbyshared.jar derbyLocale_cs.jar derbyLocale_de_DE.jar derbyLocale_es.jar derbyLocale_fr.jar derbyLocale_hu.jar derbyLocale_it.jar derbyLocale_ja_JP.jar derbyLocale_ko_KR.jar derbyLocale_pl.jar derbyLocale_pt_BR.jar derbyLocale_ru.jar derbyLocale_zh_CN.jar derbyLocale_zh_TW.jar"/>
       </manifest>
-  </target>
-
-  <target name="make-core-derbyjar-manifest">
-
-    <manifest file="${manifest.file}">
-      <attribute name="Bundle-Vendor" value="Apache Software Foundation"/>
-      <attribute name="Bundle-Name" value="Apache Derby ${major}.${minor}"/>
-      <attribute name="Bundle-Version" value="${major}.${minor}.${maint}.${changenumber}"/>
-      <attribute name="Bundle-ManifestVersion" value="2"/>
-      	<attribute name="Sealed" value="true"/>
-    	<section name="org/apache/derby/jdbc/">
-    	  <attribute name="Sealed" value="false"/>
-    	</section>
-    </manifest> 
-
-    <antcall target="make-locale-classpath-manifest">
-        <param name="manifest.file" value="${manifest.file}"/>
-        <param name="manifest.mode" value="update"/>
-    </antcall>
-
   </target>
 
 <!-- - - - - - - - - - - - -  derbytools.jar target - - - - - - - - - - -->
@@ -1512,6 +1501,20 @@
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/**"/>
     </jar>
+
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derbytools.jar"/>
+    </delete>
+    <exec executable="java"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derbytools.bnd"/>
+    </exec>
+    <jar destfile="${derby.jar.dir}/derbytools.jar"
+         manifest="bnd/derbytools.mf"
+         update="true"/>
   </target>
 
 <!-- - - - - - - - - - - - -  derbyoptionaltools.jar target - - - - - - - - - - -->
@@ -1536,33 +1539,34 @@
 
     <!-- copy boilerplate common to derby jar files -->
     <antcall target="meta-inf-common"/>
-    <manifest file="${derby.jar.dir}/lists/smfoptionaltools.mf">
-      <attribute name="Bundle-Vendor" value="Apache Software Foundation"/>
-      <attribute name="Bundle-Name" value="Apache Derby ${major}.${minor}"/>
-      <attribute name="Bundle-Version" value="${major}.${minor}.${maint}.${changenumber}"/>
-      <attribute name="Bundle-ManifestVersion" value="2"/>
-      <attribute name="Sealed" value="true"/>
-    </manifest> 
-
-    <antcall target="make-locale-classpath-manifest">
-        <param name="manifest.file" value="${derby.jar.dir}/lists/smfoptionaltools.mf"/>
-        <param name="manifest.mode" value="update"/>
-    </antcall>
 
     <delete file="${derby.jar.dir}/derbyoptionaltools.jar"/>
     <jar destfile="${derby.jar.dir}/derbyoptionaltools.jar"
          basedir="${out.optional.dir}"
-         manifest="${derby.jar.dir}/lists/smfoptionaltools.mf"
          compress="true"
          filesonly="true">
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/**"/>
     </jar>
+
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derbyoptionaltools.jar"/>
+    </delete>
+    <exec executable="java"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derbyoptionaltools.bnd"/>
+    </exec>
+    <jar destfile="${derby.jar.dir}/derbyoptionaltools.jar"
+         manifest="bnd/derbyoptionaltools.mf"
+         update="true"/>
   </target>
 
 <!-- - - - - - - - - - - - - - derbynet.jar target - - - - - - - - - - - -->
 
-  <target name="derbynetjar" depends="setsanityname">
+  <target name="derbynetjar" depends="setsanityname,versions.properties">
 
     <echo level="info" message="Beginning derbynet.jar ${sanity.name} build"/>
 
@@ -1583,27 +1587,34 @@
     <!-- copy boilerplate common to derby jar files -->
     <antcall target="meta-inf-common"/>
 
-    <manifest file="${derby.jar.dir}/lists/smfnet.mf">
-      <attribute name="Main-Class" value="org.apache.derby.drda.NetworkServerControl"/>
-      <attribute name="Class-Path" value="derby.jar derbyshared.jar derbytools.jar"/>
-      	<attribute name="Sealed" value="true"/>
-    </manifest> 
-
     <delete file="${derby.jar.dir}/derbynet.jar"/>
     <jar destfile="${derby.jar.dir}/derbynet.jar"
          basedir="${out.drda.dir}"
          compress="true"
-         filesonly="true"
-    	 manifest="${derby.jar.dir}/lists/smfnet.mf">
+         filesonly="true">
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/**"/>
     </jar>
 
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derbynet.jar"/>
+    </delete>
+    <exec executable="java"
+          failonerror="true"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derbynet.bnd"/>
+    </exec>
+    <jar destfile="${derby.jar.dir}/derbynet.jar"
+         manifest="bnd/derbynet.mf"
+         update="true"/>
   </target>
 
 <!-- - - - - - - - - - - - - - derbyclient.jar target - - - - - - - - -->
 
- <target name="derbyclientjar" depends="setsanityname,initjars">
+ <target name="derbyclientjar" depends="setsanityname,initjars,versions.properties">
 
     <echo level="info" message="Beginning derbyclient.jar ${sanity.name} build"/>
 
@@ -1623,17 +1634,6 @@
 
     <!-- copy boilerplate common to derby jar files -->
     <antcall target="meta-inf-common"/>
-    <antcall target="make-core-derbyjar-manifest">
-      <param name="manifest.file" value="${derby.jar.dir}/lists/smfclient.mf"/>
-    </antcall>
-
-    <!-- add extra osgi bits to manifest -->
-
-    <manifest file="${derby.jar.dir}/lists/smfclient.mf"  mode="update">
-      <attribute name="Bundle-SymbolicName" value="derbyclient"/>
-      <attribute name="DynamicImport-Package" value="*"/>
-      <attribute name="Export-Package" value="org.apache.derby.jdbc"/> 
-    </manifest> 
 
     <!-- declare the client driver for autoloading by the JDBC 4 DriverManager -->
     <antcall target="declare-autoloadable-driver">
@@ -1649,17 +1649,30 @@
          update="true"
          excludes="org/apache/derby/loc/clientmessages_qq_PP_testOnly.properties,
                    **/*Test.class,
-                   **/_Suite.class"
-    	 manifest="${derby.jar.dir}/lists/smfclient.mf">
+                   **/_Suite.class">
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/**"/>
     </jar>
-  </target>
 
+   <!-- Execute the bnd tool to generate a new jar manifest. -->
+   <delete>
+     <fileset dir="bnd" includes="derbyclient.jar"/>
+   </delete>
+   <exec executable="java"
+         failonerror="true"
+         failifexecutionfails="true">
+     <arg value="-jar"/>
+     <arg value="${bnd}"/>
+     <arg value="bnd/derbyclient.bnd"/>
+   </exec>
+   <jar destfile="${derby.jar.dir}/derbyclient.jar"
+        manifest="bnd/derbyclient.mf"
+        update="true"/>
+  </target>
 
 <!-- - - - - - - - - - - - - - derbyshared.jar target - - - - - - - - - - - -->
 
-  <target name="derbysharedjar" depends="setsanityname">
+  <target name="derbysharedjar" depends="setsanityname,versions.properties">
 
     <echo level="info" message="Beginning derbyshared.jar ${sanity.name} build"/>
 
@@ -1679,23 +1692,26 @@
 
     <!-- copy boilerplate common to derby jar files -->
     <antcall target="meta-inf-common"/>
-    <antcall target="make-locale-classpath-manifest">
-        <param name="manifest.file" value="${derby.jar.dir}/lists/smfshared.mf"/>
-        <param name="manifest.mode" value="update"/>
-    </antcall>
 
-    <delete file="${derby.jar.dir}/derbyshared.jar"/>
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derbyshared.jar"/>
+    </delete>
+    <exec executable="java"
+          failonerror="true"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derbyshared.bnd"/>
+    </exec>
     <jar destfile="${derby.jar.dir}/derbyshared.jar"
-         basedir="${out.shared.dir}"
-         compress="true"
-         filesonly="true"
-    	 manifest="${derby.jar.dir}/lists/smfshared.mf"/>
-
+         manifest="bnd/derbyshared.mf"
+         update="true"/>
   </target>
 
 <!-- - - - - - - - - - - - - - derbyrun.jar target  - - - - - - - - - -->
    
-  <target name="derbyrunjar" depends="setsanityname,initjars">
+  <target name="derbyrunjar" depends="setsanityname,initjars,versions.properties">
 
     <echo level="info" message="Beginning derbyrun.jar build"/>
 
@@ -1725,7 +1741,7 @@
   </target>
 <!-- - - - - - - - - - - - - - derby.war target - - - - - - - - - - - -->
 
- <target name="derbywar" depends="initjars">
+ <target name="derbywar" depends="initjars,versions.properties">
 
     <echo level="info" message="Beginning derby.war  build"/>
     <delete file="${derby.jar.dir}/derby.war"/>
@@ -1734,7 +1750,7 @@
 
 <!-- - - - - - - - - - - - - - locale jar targets - - - - - - - - - - - -->
 
-  <target name="derbylocalejars" depends="initjars">
+  <target name="derbylocalejars" depends="initjars,versions.properties">
  
     <!-- purge lists directory to avoid unnecessary content from other jars -->
     <delete>
@@ -1826,7 +1842,7 @@
     
 <!-- - - - - - - - - - - - derby testing jar target - - - - - - - - - - -->
 
-  <target name="derbytestingjar" depends="initjars,ckderbytesting" if="derbyTesting.available">
+  <target name="derbytestingjar" depends="initjars,ckderbytesting,versions.properties" if="derbyTesting.available">
     <!-- generate tsting info property file -->
     <antcall target="tstinginfowriter">
       <param name="info.buildnumber" value="${changenumber}"/>

--- a/build.xml
+++ b/build.xml
@@ -1374,7 +1374,7 @@
 
 <!-- - - - - - - - - - - - - - - derby.jar target - - - - - - - - - - - -->
 
-  <target name="derbyjar" depends="initjars,versions.properties">
+  <target name="derbyjar" depends="initjars,version.properties">
 
     <echo level="info" message="Beginning derby.jar ${sanity.name} build"/>
 
@@ -1442,7 +1442,7 @@
 
   <!-- Produce a properties file containing version information. -->
   <!-- Used when producing OSGi manifests. -->
-  <target name="versions.properties">
+  <target name="version.properties">
     <propertyfile file="classes/version.properties">
       <entry key="major" value="${major}"/>
       <entry key="minor" value="${minor}"/>
@@ -1566,7 +1566,7 @@
 
 <!-- - - - - - - - - - - - - - derbynet.jar target - - - - - - - - - - - -->
 
-  <target name="derbynetjar" depends="setsanityname,versions.properties">
+  <target name="derbynetjar" depends="setsanityname,version.properties">
 
     <echo level="info" message="Beginning derbynet.jar ${sanity.name} build"/>
 
@@ -1614,7 +1614,7 @@
 
 <!-- - - - - - - - - - - - - - derbyclient.jar target - - - - - - - - -->
 
- <target name="derbyclientjar" depends="setsanityname,initjars,versions.properties">
+ <target name="derbyclientjar" depends="setsanityname,initjars,version.properties">
 
     <echo level="info" message="Beginning derbyclient.jar ${sanity.name} build"/>
 
@@ -1672,7 +1672,7 @@
 
 <!-- - - - - - - - - - - - - - derbyshared.jar target - - - - - - - - - - - -->
 
-  <target name="derbysharedjar" depends="setsanityname,versions.properties">
+  <target name="derbysharedjar" depends="setsanityname,version.properties">
 
     <echo level="info" message="Beginning derbyshared.jar ${sanity.name} build"/>
 
@@ -1711,7 +1711,7 @@
 
 <!-- - - - - - - - - - - - - - derbyrun.jar target  - - - - - - - - - -->
    
-  <target name="derbyrunjar" depends="setsanityname,initjars,versions.properties">
+  <target name="derbyrunjar" depends="setsanityname,initjars,version.properties">
 
     <echo level="info" message="Beginning derbyrun.jar build"/>
 
@@ -1741,7 +1741,7 @@
   </target>
 <!-- - - - - - - - - - - - - - derby.war target - - - - - - - - - - - -->
 
- <target name="derbywar" depends="initjars,versions.properties">
+ <target name="derbywar" depends="initjars,version.properties">
 
     <echo level="info" message="Beginning derby.war  build"/>
     <delete file="${derby.jar.dir}/derby.war"/>
@@ -1750,7 +1750,7 @@
 
 <!-- - - - - - - - - - - - - - locale jar targets - - - - - - - - - - - -->
 
-  <target name="derbylocalejars" depends="initjars,versions.properties">
+  <target name="derbylocalejars" depends="initjars,version.properties">
  
     <!-- purge lists directory to avoid unnecessary content from other jars -->
     <delete>
@@ -1816,7 +1816,7 @@
     </antcall>
   </target>
 
-  <target name="localejar">
+  <target name="localejar" depends="version.properties">
  
     <echo level="info" message="Building derbyLocale_${locale.iname}.jar"/>
 
@@ -1833,16 +1833,44 @@
     <jar destfile="${derby.jar.dir}/derbyLocale_${locale.iname}.jar"
          basedir="${out.dir}/${locale.stub}${locale.iname}"
          compress="true"
-         filesonly="true"
-      >
+         filesonly="true">
       <fileset dir="${derby.jar.dir}/lists"
                includes="META-INF/LICENSE,META-INF/NOTICE"/>
     </jar>
+
+    <antcall target="locale.properties">
+      <param name="locale.iname" value="${locale.iname}"/>
+      <param name="locale.ename" value="${locale.ename}"/>
+    </antcall>
+
+    <!-- Execute the bnd tool to generate a new jar manifest. -->
+    <delete>
+      <fileset dir="bnd" includes="derbyLocale_${locale.iname}.jar"/>
+    </delete>
+    <exec executable="java"
+          failonerror="true"
+          failifexecutionfails="true">
+      <arg value="-jar"/>
+      <arg value="${bnd}"/>
+      <arg value="bnd/derbyLocale.bnd"/>
+    </exec>
+    <jar destfile="${derby.jar.dir}/derbyLocale_${locale.iname}.jar"
+         manifest="bnd/derbyLocale_${locale.iname}.mf"
+         update="true"/>
   </target>
-    
+
+  <!-- Produce a properties file containing locale information. -->
+  <!-- Used when producing OSGi manifests. -->
+  <target name="locale.properties">
+    <propertyfile file="classes/locale.properties">
+      <entry key="locale.iname" value="${locale.iname}"/>
+      <entry key="locale.ename" value="${locale.ename}"/>
+    </propertyfile>
+  </target>
+
 <!-- - - - - - - - - - - - derby testing jar target - - - - - - - - - - -->
 
-  <target name="derbytestingjar" depends="initjars,ckderbytesting,versions.properties" if="derbyTesting.available">
+  <target name="derbytestingjar" depends="initjars,ckderbytesting,version.properties" if="derbyTesting.available">
     <!-- generate tsting info property file -->
     <antcall target="tstinginfowriter">
       <param name="info.buildnumber" value="${changenumber}"/>

--- a/java/org.apache.derby.engine/org/apache/derby/osgi/EmbeddedActivator.java
+++ b/java/org.apache.derby.engine/org/apache/derby/osgi/EmbeddedActivator.java
@@ -30,14 +30,11 @@ import org.osgi.framework.BundleContext;
 public final class EmbeddedActivator implements BundleActivator {
 
 	public void start(BundleContext context) {
-		new org.apache.derby.iapi.jdbc.AutoloadedDriver();
+
 	}
 
 	public void stop(BundleContext context) {
-		try {
-			DriverManager.getConnection("jdbc:derby:;shutdown=true");
-		} catch (SQLException sqle) {
-		}
+
 	}
 }
 

--- a/tools/ant/properties/dirs.properties
+++ b/tools/ant/properties/dirs.properties
@@ -60,6 +60,7 @@ out.testdir=${out.base}/testout_${jdk}
 drdaloc.dir=${out.drda.dir}/org/apache/derby/loc/drda
 jarsdist.dir=${out.base}/jars
 
+out.bnd.dir=${out.dir}/bnd
 out.build.dir=${out.dir}/build
 out.client.dir=${out.dir}/client
 out.demo.dir=${out.dir}/demo

--- a/tools/ant/properties/extrapath.properties
+++ b/tools/ant/properties/extrapath.properties
@@ -32,6 +32,7 @@ lucene_core=${javatools.dir}/lucene-core.jar
 lucene_a_co=${javatools.dir}/lucene-analyzers-common.jar
 lucene_qp=${javatools.dir}/lucene-queryparser.jar
 json_simple=${javatools.dir}/json_simple-1.1.jar
+bnd=${javatools.dir}/biz.aQute.bnd-4.3.0.jar
 
 #
 # Base JavaDoc collection, used for both product and test JavaDocs.


### PR DESCRIPTION
This set of commits makes the following changes:

- All jar manifests are now generated using the [Bnd](https://bnd.bndtools.org/) tool. The new manifests contain a superset of the old manifests with the addition of OSGi headers. This is achieved by using `.bnd` files instead of raw `.mf` manifest files, with the `bnd` tool expanding properties inside the `.bnd` files to produce manifests which are then inserted into jar files directly.
- The locale jars have manifest headers that allow them to act as "fragments". A fragment, in OSGi terms, more or less acts like an extension to an existing jar file. Primarily, this is used to introduce locale-specific string resources into an existing jar.
- The existing `BundleActivator` class has essentially been eliminated; the class still exists but does nothing.